### PR TITLE
Add custom exercise documentation

### DIFF
--- a/docs/source/contributing/custom_exercises.rst
+++ b/docs/source/contributing/custom_exercises.rst
@@ -1,22 +1,97 @@
 .. _custom_exercises:
 
+.. |Client| replace:: :py:class:`Client <cryptoserve.messaging.client.Client>`
+.. |expect| replace:: :py:meth:`expect <cryptoserve.messaging.client.Client.expect>`
+.. |send| replace:: :py:meth:`send <cryptoserve.messaging.client.Client.send>`
+.. |ExerciseError| replace:: :py:class:`ExerciseError <cryptoserve.types.errors.ExerciseError>`
+
 Custom Exercises
 ================
 
-Cryptoserve can be easily extended to add your own exercises. Here is a short list of steps to do so:
+Cryptoserve can also be easily extended to add your own exercises! The process is not too difficult overall,
+but there are a couple of specifics that you should be aware of though.
 
 
-1. **Create a Python file**.
-2. **Implement your exercise** as a Python function with the following signature:
+Creating the Exercise
+---------------------
+
+To create a new exercise, simply create a new Python file with a descriptive name.
+
+.. code-block:: shell
+
+   vim your_custom_exercise.py  # Or use your preferred code-editor.
+
+This file will house all the code that the exercise needs to run properly.
+
+
+Implementing the Exercise
+-------------------------
+
+Inside your Python file, you are required to implement one function:
 
 .. code-block:: python
 
-   def your_custom_exercise(client: Client):
+   def your_custom_exercise(client: Client) -> None:
       pass
 
-.. note:: Please refer to the internal documentation for how to use the Client class.
+This function should recieve one argument: an instance of the |Client| class, which is used to send
+messages back and forth from the user. To be recognized by Cryptoserve as a valid exercise, the function header
+**must use type hints**, return **None**, and the function name **must not be prefixed with an underscore** (i.e. it must be public).
 
-.. note:: The name of your function will be converted from snakecase and used as the exercise name. 
+.. note:: The name of your function will be converted from snakecase and used as the exercise name.
 
-3. **Restart Cryptoserve**. Future students should now be able to connect to the server and select your exercises from the avialble list.
-4. **Document your exercise**. Please see Contributing for how to document your exercise.
+
+Recieving Data and Checking for Errors
+--------------------------------------
+
+The two methods you are probably most interested in are:
+
+1. |expect| for recieving data.
+2. |send| for sending data.
+
+|expect| is used to read from the socket. It takes optional arguments for verifying the length of the data recieved
+as well as an function that is used to verify or transform the recieved data in some way. For instance, let's say
+you expected to recieve a pair of bytes that are coprime for some purpose. You could accomplish that like so:
+
+.. code-block:: python
+
+   from math import gcd
+
+   def verify_byte_pair_is_coprime(data: bytes):
+      if gcd(data[0], data[1]) == 1:
+         raise ExerciseError(
+            error="short Pythonic error message",
+            explanation="A longer English-style sentence or two about what the user did wrong.",
+            hints=[
+               "A list of hints to help guide the user to make corrections.",
+               "It can be any number of strings.",
+               "This argument can also be None if no hints are warranted."
+            ]
+         )
+
+      return data
+
+   data = client.expect(length=2, verifier=verify_byte_pair_is_coprime)
+   # From this point on, you can assume data refers to a valid byte pair...
+
+.. warning:: Because Cryptoserve is an asynchronous server, you must use the ``await`` keyword when calling (most) methods from the |Client| class!
+
+Notice how the verifier function does not explicitly check the length of `data`. This is because the length of the bytes
+passed to the function is checked before the verifier is called, so the length is guaranteed to be 2. If you need more complex
+length-checking or want more explicit, you must place that logic in the verifier itself.
+
+To stop the exercise due to an error, simply raise an instance of |ExerciseError|. There are also various subclasses with different names
+but have the same functionality. Choose the one with the name that gives the most insight into what went wrong or make your own subclass!
+
+
+Making You Exercise Available
+-----------------------------
+
+Once you have implemented (and tested) your exercise the only thing left to do is to drop it into the **exercises** folder.
+
+.. code-block:: shell
+
+   mv your_custom_exercise.py cryptoserve/src/exercises/your_custom_exercise.py
+
+The next time the server restarts, Cryptoserve automatically scans this folder to locate all the exercise functions. This process is also recursive,
+so feel free to change the directory structure and organize the folders as you see fit.

--- a/src/cryptoserve/exercises/__init__.py
+++ b/src/cryptoserve/exercises/__init__.py
@@ -1,1 +1,41 @@
-from cryptoserve.exercises.simple_hash import simple_hash
+import importlib
+import inspect
+import os
+from types import FunctionType
+from typing import get_type_hints
+
+from cryptoserve.messaging.client import Client
+
+
+def load_exercises(directory: str):
+    exercises = []
+
+    for dirpath, _, filenames in os.walk(directory):
+        for filename in filenames:
+            if filename.endswith(".py"):
+                filepath = os.path.join(dirpath, filename)
+
+                try:
+                    spec = importlib.util.spec_from_file_location("exercises", filepath)
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module)
+                except Exception as e:
+                    continue
+
+                for name, member in inspect.getmembers(module, inspect.isfunction):
+                    if not name.startswith("_") and _has_exercise_signature(member):
+                        exercises.append((name, member))
+
+    return exercises
+
+
+def _has_exercise_signature(function: FunctionType):
+    signature = inspect.signature(function)
+    hints = get_type_hints(function)
+    parameters = list(signature.parameters.values())
+
+    return (
+        len(parameters) == 1
+        and hints.get(parameters[0].name) is Client
+        and hints.get("return") is None
+    )

--- a/src/cryptoserve/exercises/__init__.py
+++ b/src/cryptoserve/exercises/__init__.py
@@ -1,13 +1,30 @@
 import importlib
 import inspect
 import os
-from types import FunctionType
 from typing import get_type_hints
 
 from cryptoserve.messaging.client import Client
 
 
-def load_exercises(directory: str):
+def load_exercises(directory: str) -> list[tuple[str, callable]]:
+    """
+    Load Cryptoserve exercises from a directory.
+
+    This method recursively searches through a directory for Python files to find functions that look like
+    Cryptoserve exercises. The file must end with the **.py** file extension but doesn't have to be in a folder
+    with the standard Python package structure.
+
+    Valid exercise functions have two requirements:
+
+    1. The function must **not be private** (i.e. it's name doesn't start with and underscore).
+    2. The function must have the following signature specified with type hints: **(Client) -> None**
+
+    Args:
+        directory: The directory path to recursively search
+
+    Returns:
+        list[tuple[str, callable]]: A list of (exercise name, function) tuples for valid exercise functions.
+    """
     exercises = []
 
     for dirpath, _, filenames in os.walk(directory):
@@ -19,7 +36,7 @@ def load_exercises(directory: str):
                     spec = importlib.util.spec_from_file_location("exercises", filepath)
                     module = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(module)
-                except Exception as e:
+                except Exception:
                     continue
 
                 for name, member in inspect.getmembers(module, inspect.isfunction):
@@ -29,7 +46,21 @@ def load_exercises(directory: str):
     return exercises
 
 
-def _has_exercise_signature(function: FunctionType):
+def _has_exercise_signature(function: callable):
+    """
+    Check if the callable object has the correct signature to be considered a Cryptoserve exercise.
+
+    Returns True if the function name is not prefixed with an underscore (_) and has the signature **(Client) -> None**.
+    The function must use type hints in order to be recognized as a proper exercise.
+
+    Example: ``def my_exercise(client: Client) -> None:``
+
+    Args:
+        function (callable): The function object to test.
+
+    Returns:
+        bool: True if the function matches all the criteria, False otherwise.
+    """
     signature = inspect.signature(function)
     hints = get_type_hints(function)
     parameters = list(signature.parameters.values())

--- a/src/cryptoserve/exercises/simple_hash.py
+++ b/src/cryptoserve/exercises/simple_hash.py
@@ -67,6 +67,7 @@ def verify_padded_data(
         byte == 0x00 for byte in padded_data[-padding_amount:]
     ):
         raise InvalidPaddingError(
+            error="recieved data has invalid padding",
             explanation="The original data was padded improperly.",
             hints=[
                 "Is padding applied only to the end of the data to be hashed?",
@@ -87,7 +88,7 @@ def verify_hash(data: bytes, hash: uint16) -> uint16:
 
     if recieved_hash != hash:
         raise DataMismatchError(
-            data_type="hash",
+            error="recieved data does not match expected hash",
             explanation="You made some mistake in hashing.",
             hints=[
                 "Are you applying the operations in the correct order as outlined in the documentation?",
@@ -96,4 +97,5 @@ def verify_hash(data: bytes, hash: uint16) -> uint16:
                 "Are you sending the data in the correct order?",
             ],
         )
+
     return hash

--- a/src/cryptoserve/greeting.py
+++ b/src/cryptoserve/greeting.py
@@ -1,6 +1,8 @@
+import os
 from inspect import getmembers, isfunction
 
 import cryptoserve.exercises
+from cryptoserve.exercises import load_exercises
 from cryptoserve.messaging.text_menu import TextMenu
 
 DOCUMENTATION_LINK = "https://cryptoserve.readthedocs.io/"
@@ -34,7 +36,10 @@ menu.add_section("Available Exercises", "exercises")
 numbered_exercise_names = []
 EXERCISES = []
 
-for i, (name, exercise) in enumerate(getmembers(cryptoserve.exercises, isfunction)):
+path = os.path.dirname(cryptoserve.exercises.__file__)
+
+
+for i, (name, exercise) in enumerate(load_exercises(path)):
     exercise_converted_from_snakecase = name.replace("_", " ").title()
     number = f"{i:<1}. "
     numbered_line = f"{number}{exercise_converted_from_snakecase}"

--- a/src/cryptoserve/messaging/client.py
+++ b/src/cryptoserve/messaging/client.py
@@ -1,20 +1,34 @@
+"""
+Interface for facilitating communication between the client and server.
+
+
+This module defines the ``Client`` class which abstracts the details away of the network protocol. It handles the details
+of encapsulating data for transmission so the developer can concern themselves with the data themselves instead of
+worrying about the protocol details. It also provides some utilities for error-checking data recieved from a client
+during the course of an exercise.
+"""
+
 import asyncio
 from typing import Any, Callable, Optional
 
 from cryptoserve.types import DataTransmissionError
 
 HEADER_LENGTH_BYTES = 2
+OK_MESSAGE = "OK"
 
 
 class Client:
     """
+    Interface for sending and receiving data from a user.
+
     This class is used as an interface for sending and recieving data from a socket between the client and server.
     It provides various utilities to abstract the underlying protocol information to send blobs of data back and
     forth in an asynchronous manner.
     """
 
     def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
-        """Constructor method.
+        """
+        Constructor method.
 
         Args:
             reader: Reader instance for reading from the socket. This should not be instantiated directly but rather
@@ -81,7 +95,7 @@ class Client:
             Any: The raw bytes, or the result of the verifier function.
 
         Raises:
-            ValueError: If the message length does not match the expected length.
+            DataTransmissionError: If the message length does not match the expected length.
         """
         raw_bytes = await self._recieve()
 
@@ -141,5 +155,5 @@ class Client:
         Sends the string "OK" to the client. Use this to confirm data sent by the client
         when no other response is applicable.
         """
-        raw_bytes = "OK".encode()
+        raw_bytes = OK_MESSAGE.encode()
         await self.send(raw_bytes)

--- a/src/cryptoserve/types/errors.py
+++ b/src/cryptoserve/types/errors.py
@@ -21,31 +21,15 @@ class ExerciseError(Exception):
 
 
 class InvalidPaddingError(ExerciseError):
-    def __init__(self, explanation: str = "", hints: Optional[List[str]] = None):
-        error = "data has invalid padding"
-        super().__init__(error, explanation, hints)
+    pass
 
 
 class InvalidLengthError(ExerciseError):
-    def __init__(
-        self,
-        size_adjective: str = "large",
-        explanation: str = "",
-        hints: Optional[List[str]] = None,
-    ):
-        error = f"data is too {size_adjective}"
-        super().__init__(error, explanation, hints)
+    pass
 
 
 class DataMismatchError(ExerciseError):
-    def __init__(
-        self,
-        data_type: str = "data",
-        explanation: str = "",
-        hints: Optional[List[str]] = None,
-    ):
-        error = f"recieved {data_type} does not match expected {data_type}"
-        super().__init__(error, explanation, hints)
+    pass
 
 
 class DataTransmissionError(ExerciseError):


### PR DESCRIPTION
This PR adds more guidelines on how to extend Cryptoserve with custom exercises. This also adds functionality for Cryptoserve to scan the ``exercises`` folder to dynamically add exercises on startup.