### PR TITLE
Switch to plantuml diagrams

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,6 @@ author = "Eric Brown"
 
 extensions = [
     "sphinxcontrib.plantuml",
-    "sphinxcontrib.mermaid",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@ author = "Eric Brown"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    "sphinxcontrib.plantuml",
     "sphinxcontrib.mermaid",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",

--- a/docs/source/exercises/simple_hash.rst
+++ b/docs/source/exercises/simple_hash.rst
@@ -85,34 +85,48 @@ Here is a visual representation of the client-server interaction where...
 - **cᵢ** is the i-th chunk of input data.
 - **n** is the total number of chunks to be hashed.
 
-.. mermaid::
+.. uml::
 
-   sequenceDiagram
-      participant Client
-      participant Server
+   participant Client
+   participant Server
 
-      Client->>Server: Input
-      Server-->>Client: OK
+   Client ->> Server : Input
+   Server -->> Client : OK
 
-      Client->>Server: Padded Input
-      Server-->>Client: OK
+   Client ->> Server : Padded Input
+   Server -->> Client : OK
 
-      Note over Client: h₀ ← [Input.length, Input.length]
-      Note over Client: h₁ ← f(h₀, c₁)
-      Client->>Server: h₁
+   note over Client
+     h₀ ← [Input.length, Input.length]
+   end note
 
-      Note over Server: h₂ ← g(h₁, c₂)
-      Server-->>Client: h₂
+   note over Client
+     h₁ ← f(h₀, c₁)
+   end note
 
-      loop for (i = 3, i < n, i += 2)
-         Note over Client: hᵢ ← f(hᵢ₋₁, cᵢ)
-         Client->>Server: hᵢ
+   Client ->> Server : h₁
 
-         Note over Server: hᵢ₊₁ ← g(hᵢ, cᵢ₊₁)
-         Server-->>Client: hᵢ₊₁
-      end
+   note over Server
+     h₂ ← g(h₁, c₂)
+   end note
 
-      Note over Client, Server: Final Hash = hₙ
+   Server -->> Client : h₂
+
+   loop for (i = 3, i < n, i += 2)
+     note over Client
+       hᵢ ← f(hᵢ₋₁, cᵢ)
+     end note
+     Client ->> Server : hᵢ
+
+     note over Server
+       hᵢ₊₁ ← g(hᵢ, cᵢ₊₁)
+     end note
+     Server -->> Client : hᵢ₊₁
+   end
+
+   note over Client, Server
+     Final Hash = hₙ
+   end note
 
 
 Example
@@ -151,40 +165,51 @@ Data Exchange
 
    The use of **loop** here is solely intended to visually section off each chunk of data.
 
-.. mermaid::
+.. uml::
 
-   sequenceDiagram
-      participant Client
-      participant Server
+   participant Client
+   participant Server
 
-      Client->>Server: 0x4170 706C 65
-      Server-->>Client: OK
+   Client ->> Server : 0x4170 706C 65
+   Server -->> Client : OK
 
-      Client->>Server: 0x4170 706C 6500 0000
-      Server-->>Client: OK
+   Client ->> Server : 0x4170 706C 6500 0000
+   Server -->> Client : OK
 
-      Note over Client: h₀ = 0x0505
+   note over Client
+     h₀ = 0x0505
+   end note
 
-      loop chunk 1
-         Note over Client: h₁ = f(0x0505, 0x4170) = 0x3A58
-         Client->>Server: h₁
-      end
+   loop chunk 1
+     note over Client
+       h₁ = f(0x0505, 0x4170) = 0x3A58
+     end note
+     Client ->> Server : h₁
+   end
 
-      loop chunk 2
-         Note over Server: h₂ = g(0x3A58, 0x706C) = 0x0AA0
-         Client->>Server: h₂
-      end
+   loop chunk 2
+     note over Server
+       h₂ = g(0x3A58, 0x706C) = 0x0AA0
+     end note
+     Client ->> Server : h₂
+   end
 
-      loop chunk 3
-         Note over Client: h₃ = f(0x0AA0, 0x6500) = 0x7BF1
-         Client->>Server: h₃
-      end
+   loop chunk 3
+     note over Client
+       h₃ = f(0x0AA0, 0x6500) = 0x7BF1
+     end note
+     Client ->> Server : h₃
+   end
 
-      loop chunk 4
-         Note over Server: h₄ = g(0x7BF1, 0x0000) = 0x62AE
-         Client->>Server: h₄
-      end
+   loop chunk 4
+     note over Server
+       h₄ = g(0x7BF1, 0x0000) = 0x62AE
+     end note
+     Client ->> Server : h₄
+   end
 
-      Note over Client, Server: Final Hash = h₄ = 0x62AE
+   note over Client, Server
+     Final Hash = h₄ = 0x62AE
+   end note
 
 Therefore, the **Simple Hash** of **Apple** is 0x62AE.

--- a/docs/source/usage/protocol.rst
+++ b/docs/source/usage/protocol.rst
@@ -26,19 +26,7 @@ Header Format
 The message header is **four bytes** in size. The two most significant bytes (first two) are reserved for message flags
 while the least significant (last two) are reserved for the message size. The most significant flag byte is reserved for
 server flags which give the user notice about how to interpret the message while the other flag byte is reserved for
-exercise use if needed. Here is a visual diagram that shows the number of bits in each field. Please note that the numbers
-shown are **not** the bit numbers used in the rest of the documentation as they are reversed (i.e. bit 0 in the diagram is
-actually bit 7 of the server flags).
-
-.. mermaid::
-
-  ---
-  title: "Header Format (bits)"
-  ---
-  packet-beta
-    0-7: "Server Flags"
-    8-15: "Exercise Flags"
-    16-31: "Message Length"
+exercise use if needed.
 
 .. note::  Because there are 16 bits used for the message length field, the maximum payload size is **65535** bytes (2¹⁶ - 1).
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -850,6 +850,23 @@ sphinx = "*"
 test = ["defusedxml", "myst-parser", "pytest", "ruff", "sphinx"]
 
 [[package]]
+name = "sphinxcontrib-plantuml"
+version = "0.30"
+description = "Sphinx \"plantuml\" extension"
+optional = false
+python-versions = "*"
+groups = ["docs"]
+files = [
+    {file = "sphinxcontrib-plantuml-0.30.tar.gz", hash = "sha256:2a1266ca43bddf44640ae44107003df4490de2b3c3154a0d627cfb63e9a169bf"},
+]
+
+[package.dependencies]
+Sphinx = ">=1.6"
+
+[package.extras]
+test = ["Pillow", "flake8", "pytest"]
+
+[[package]]
 name = "sphinxcontrib-qthelp"
 version = "2.0.0"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents"
@@ -904,4 +921,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "b6271b5abf10d49bddfe8f56b986ff15946764f8ff242698e53b383c23b11b85"
+content-hash = "9c9fc7c2f2ffdeabea2867ac136c287a10008e842098909cd35e85f1b8c510c4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -543,69 +543,6 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
-name = "pyyaml"
-version = "6.0.2"
-description = "YAML parser and emitter for Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["docs"]
-files = [
-    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
-    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
-    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
-    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
-    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
-    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
-    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
-    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
-    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
-    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
-    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
-    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
-    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
-    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
-    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
-    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
-    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
-    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
-    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
-    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
-    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
-    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
-    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
-    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
-    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
-    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
-    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
-    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
-    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
-    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
-    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
-    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
-    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
-    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
-    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
-]
-
-[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -831,25 +768,6 @@ files = [
 test = ["flake8", "mypy", "pytest"]
 
 [[package]]
-name = "sphinxcontrib-mermaid"
-version = "1.0.0"
-description = "Mermaid diagrams in yours Sphinx powered docs"
-optional = false
-python-versions = ">=3.8"
-groups = ["docs"]
-files = [
-    {file = "sphinxcontrib_mermaid-1.0.0-py3-none-any.whl", hash = "sha256:60b72710ea02087f212028feb09711225fbc2e343a10d34822fe787510e1caa3"},
-    {file = "sphinxcontrib_mermaid-1.0.0.tar.gz", hash = "sha256:2e8ab67d3e1e2816663f9347d026a8dee4a858acdd4ad32dd1c808893db88146"},
-]
-
-[package.dependencies]
-pyyaml = "*"
-sphinx = "*"
-
-[package.extras]
-test = ["defusedxml", "myst-parser", "pytest", "ruff", "sphinx"]
-
-[[package]]
 name = "sphinxcontrib-plantuml"
 version = "0.30"
 description = "Sphinx \"plantuml\" extension"
@@ -921,4 +839,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "9c9fc7c2f2ffdeabea2867ac136c287a10008e842098909cd35e85f1b8c510c4"
+content-hash = "6f15eefcbe14d0dc53df9442825d7e03cebcdbf272f734c383cb298e67aea693"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ sphinx = "^8.2.3"
 sphinx-rtd-theme = "^3.0.2"
 sphinxcontrib-mermaid = "^1.0.0"
 sphinx-autodoc-typehints = "^3.2.0"
+sphinxcontrib-plantuml = "^0.30"
 
 [tool.poetry.group.tests.dependencies]
 pytest = "^8.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 sphinx = "^8.2.3"
 sphinx-rtd-theme = "^3.0.2"
-sphinxcontrib-mermaid = "^1.0.0"
 sphinx-autodoc-typehints = "^3.2.0"
 sphinxcontrib-plantuml = "^0.30"
 


### PR DESCRIPTION
## Description

This PR replaces the previously [Mermaid](https://mermaid.js.org/) sequence diagrams with [PlantUML](https://plantuml.com/) ones. This is so the diagrams will be rendered in the downloadable versions of the documentation, something not possible the with JS libraries.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor

## Checklist

- [x] Was the content of this PR discussed and approved via a GitHub issue? (if necessary)
- [x] Did you make sure that your PR does only one thing instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests?
- [x] Did you verify new and existing tests pass locally with your changes?
